### PR TITLE
test/fix random tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,6 @@ dependencies = [
 name = "cosmian_pkcs11"
 version = "0.2.0"
 dependencies = [
- "cosmian_kmip",
  "cosmian_kms_client",
  "cosmian_logger",
  "cosmian_pkcs11_module",
@@ -6551,8 +6550,6 @@ dependencies = [
  "actix-server",
  "base64 0.22.1",
  "cosmian_cli",
- "cosmian_kms_client",
- "cosmian_kms_crypto",
  "cosmian_kms_server",
  "cosmian_kms_server_database",
  "cosmian_logger",

--- a/crate/cli/src/lib.rs
+++ b/crate/cli/src/lib.rs
@@ -34,5 +34,11 @@ pub mod error;
 
 pub use commands::{Cli, CliCommands, cosmian_main};
 
+pub mod reexport {
+    pub use cosmian_findex_client;
+    pub use cosmian_kms_client;
+    pub use cosmian_kms_crypto;
+}
+
 #[cfg(test)]
 mod tests;

--- a/crate/cli/src/tests/kms/certificates/encrypt.rs
+++ b/crate/cli/src/tests/kms/certificates/encrypt.rs
@@ -221,8 +221,8 @@ async fn import_encrypt_decrypt(
     // let tmp_path = std::path::Path::new("./");
 
     let input_file = PathBuf::from("../../test_data/plain.txt");
-    let output_file = tmp_path.join("plain.enc");
-    let recovered_file = tmp_path.join("plain.txt");
+    let output_file = tmp_path.join(format!("{filename}-plain.enc"));
+    let recovered_file = tmp_path.join(format!("{filename}-plain.txt"));
 
     let tags = &[filename];
 
@@ -269,7 +269,7 @@ async fn import_encrypt_decrypt(
     )?;
 
     debug!("\n\nExport Private key wrapping with X509 certificate");
-    let private_key_wrapped = "/tmp/wrapped_private_key_exported.json".to_owned();
+    let private_key_wrapped = format!("/tmp/wrapped_{filename}_private_key_exported.json");
 
     export_key(ExportKeyParams {
         cli_conf_path: ctx.owner_client_conf_path.clone(),
@@ -311,7 +311,7 @@ async fn import_encrypt_decrypt(
 
     debug!("\n\nExport the wrapped Private key without unwrapping");
     let private_key_wrapped_as_is = tmp_path
-        .join("wrapped_private_key.json")
+        .join(format!("wrapped_{filename}_private_key.json"))
         .to_str()
         .unwrap()
         .to_owned();

--- a/crate/pkcs11/provider/Cargo.toml
+++ b/crate/pkcs11/provider/Cargo.toml
@@ -15,12 +15,10 @@ crate-type = ["rlib", "dylib"]
 doctest = false
 
 [features]
-fips = ["cosmian_kmip/fips", "cosmian_kms_client/fips", "test_kms_server/fips"]
+fips = ["cosmian_kms_client/fips", "test_kms_server/fips"]
 
 [dependencies]
-cosmian_kmip = { workspace = true }
-cosmian_cli = { path = "../../cli" }
-cosmian_crypto_core = { workspace = true }
+cosmian_kms_client = { path = "../../kms_client" }
 cosmian_pkcs11_module = { path = "../module" }
 etcetera = "0.8.0"
 p256 = { version = "0.13.2", default-features = false, features = [

--- a/crate/pkcs11/provider/Cargo.toml
+++ b/crate/pkcs11/provider/Cargo.toml
@@ -19,7 +19,8 @@ fips = ["cosmian_kmip/fips", "cosmian_kms_client/fips", "test_kms_server/fips"]
 
 [dependencies]
 cosmian_kmip = { workspace = true }
-cosmian_kms_client = { path = "../../kms_client" }
+cosmian_cli = { path = "../../cli" }
+cosmian_crypto_core = { workspace = true }
 cosmian_pkcs11_module = { path = "../module" }
 etcetera = "0.8.0"
 p256 = { version = "0.13.2", default-features = false, features = [

--- a/crate/pkcs11/provider/src/backend.rs
+++ b/crate/pkcs11/provider/src/backend.rs
@@ -23,7 +23,7 @@ use crate::{
     pkcs11_private_key::Pkcs11PrivateKey,
 };
 
-const COSMIAN_PKCS11_DISK_ENCRYPTION_TAG: &str = "disk-encryption";
+pub(crate) const COSMIAN_PKCS11_DISK_ENCRYPTION_TAG: &str = "disk-encryption";
 
 pub(crate) struct CliBackend {
     kms_rest_client: KmsClient,

--- a/crate/pkcs11/provider/src/backend.rs
+++ b/crate/pkcs11/provider/src/backend.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
-use cosmian_kmip::kmip_2_1::kmip_types::KeyFormatType;
-use cosmian_kms_client::KmsClient;
+use cosmian_kms_client::{KmsClient, reexport::cosmian_kmip::kmip_2_1::kmip_types::KeyFormatType};
 use cosmian_pkcs11_module::{
     MError, MResult,
     traits::{

--- a/crate/pkcs11/provider/src/error/mod.rs
+++ b/crate/pkcs11/provider/src/error/mod.rs
@@ -1,7 +1,9 @@
 use std::{array::TryFromSliceError, str::Utf8Error};
 
-use cosmian_kmip::{KmipError, kmip_2_1::kmip_operations::ErrorReason};
-use cosmian_kms_client::KmsClientError;
+use cosmian_kms_client::{
+    KmsClientError,
+    reexport::cosmian_kmip::{KmipError, kmip_2_1::kmip_operations::ErrorReason},
+};
 use thiserror::Error;
 
 pub(crate) mod result;

--- a/crate/pkcs11/provider/src/kms_object.rs
+++ b/crate/pkcs11/provider/src/kms_object.rs
@@ -1,13 +1,13 @@
-use cosmian_kmip::kmip_2_1::{
-    kmip_objects::Object,
-    kmip_operations::{Decrypt, GetAttributes, Locate},
-    kmip_types::{
-        Attributes, CryptographicAlgorithm, CryptographicParameters, KeyFormatType, PaddingMethod,
-        RecommendedCurve, UniqueIdentifier,
-    },
-};
 use cosmian_kms_client::{
     ExportObjectParams, KmsClient, KmsClientConfig, batch_export_objects, export_object,
+    reexport::cosmian_kmip::kmip_2_1::{
+        kmip_objects::Object,
+        kmip_operations::{Decrypt, GetAttributes, Locate},
+        kmip_types::{
+            Attributes, CryptographicAlgorithm, CryptographicParameters, KeyFormatType,
+            PaddingMethod, RecommendedCurve, UniqueIdentifier,
+        },
+    },
 };
 use cosmian_pkcs11_module::traits::{EncryptionAlgorithm, KeyAlgorithm};
 use tracing::{debug, error, trace};

--- a/crate/pkcs11/provider/src/pkcs11_certificate.rs
+++ b/crate/pkcs11/provider/src/pkcs11_certificate.rs
@@ -1,4 +1,4 @@
-use cosmian_kmip::kmip_2_1::{
+use cosmian_kms_client::reexport::cosmian_kmip::kmip_2_1::{
     kmip_objects::Object,
     kmip_types::{CertificateType, LinkType},
 };

--- a/crate/pkcs11/provider/src/tests.rs
+++ b/crate/pkcs11/provider/src/tests.rs
@@ -1,10 +1,12 @@
-use cosmian_kmip::kmip_2_1::{
-    kmip_data_structures::{KeyBlock, KeyMaterial, KeyValue},
-    kmip_objects::Object,
-    kmip_types::{CryptographicAlgorithm, KeyFormatType},
-    requests::create_symmetric_key_kmip_object,
+use cosmian_kms_client::{
+    KmsClient, import_object,
+    reexport::cosmian_kmip::kmip_2_1::{
+        kmip_data_structures::{KeyBlock, KeyMaterial, KeyValue},
+        kmip_objects::Object,
+        kmip_types::{CryptographicAlgorithm, KeyFormatType},
+        requests::create_symmetric_key_kmip_object,
+    },
 };
-use cosmian_kms_client::{KmsClient, import_object};
 use cosmian_logger::log_init;
 use cosmian_pkcs11_module::traits::Backend;
 use test_kms_server::start_default_test_kms_server;
@@ -116,7 +118,7 @@ async fn test_kms_client() -> Result<(), Pkcs11Error> {
     let keys = get_kms_objects_async(
         &kms_rest_client,
         &[COSMIAN_PKCS11_DISK_ENCRYPTION_TAG.to_owned()],
-        Some(KeyFormatType::Raw),
+        KeyFormatType::Raw,
     )
     .await?;
     assert_eq!(keys.len(), 2);

--- a/crate/test_kms_server/Cargo.toml
+++ b/crate/test_kms_server/Cargo.toml
@@ -14,8 +14,6 @@ doctest = false
 
 [features]
 fips = [
-  "cosmian_kms_client/fips",
-  "cosmian_kms_crypto/fips",
   "cosmian_cli/fips",
   "cosmian_kms_server/fips",
 ]
@@ -28,8 +26,6 @@ harness = false
 actix-server = { workspace = true }
 base64 = { workspace = true }
 cosmian_cli = { path = "../cli" }
-cosmian_kms_client = { path = "../kms_client" }
-cosmian_kms_crypto = { workspace = true }
 cosmian_kms_server = { workspace = true, features = ["insecure"] }
 cosmian_kms_server_database = { workspace = true }
 cosmian_logger = { workspace = true }

--- a/crate/test_kms_server/benches/rsa_benches.rs
+++ b/crate/test_kms_server/benches/rsa_benches.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use cosmian_kms_client::{
+use cosmian_cli::reexport::cosmian_kms_client::{
     KmsClient,
     kmip_2_1::requests::{create_rsa_key_pair_request, decrypt_request, encrypt_request},
     reexport::cosmian_kmip::kmip_2_1::{

--- a/crate/test_kms_server/benches/symmetric_benches.rs
+++ b/crate/test_kms_server/benches/symmetric_benches.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use cosmian_kms_client::{
+use cosmian_cli::reexport::cosmian_kms_client::{
     KmsClient, KmsClientError,
     reexport::cosmian_kmip::kmip_2_1::{
         extra::BulkData,

--- a/crate/test_kms_server/src/test_server.rs
+++ b/crate/test_kms_server/src/test_server.rs
@@ -8,13 +8,18 @@ use std::{
 
 use actix_server::ServerHandle;
 use base64::{Engine as _, engine::general_purpose::STANDARD as b64};
-use cosmian_cli::config::ClientConfig;
-use cosmian_kms_client::{
-    GmailApiConf, KmsClient, KmsClientConfig, KmsClientError, kms_client_bail, kms_client_error,
-    reexport::{cosmian_config_utils::ConfigUtils, cosmian_http_client::HttpClientConfig},
-};
-use cosmian_kms_crypto::crypto::{
-    secret::Secret, symmetric::symmetric_ciphers::AES_256_GCM_KEY_LENGTH,
+use cosmian_cli::{
+    config::ClientConfig,
+    reexport::{
+        cosmian_kms_client::{
+            GmailApiConf, KmsClient, KmsClientConfig, KmsClientError, kms_client_bail,
+            kms_client_error,
+            reexport::{cosmian_config_utils::ConfigUtils, cosmian_http_client::HttpClientConfig},
+        },
+        cosmian_kms_crypto::crypto::{
+            secret::Secret, symmetric::symmetric_ciphers::AES_256_GCM_KEY_LENGTH,
+        },
+    },
 };
 use cosmian_kms_server::{
     config::{ClapConfig, HttpConfig, HttpParams, JwtAuthConfig, MainDBConfig, ServerParams},


### PR DESCRIPTION
- bug fix in `test_kms_client`: `test_backend` was sometimes played before `test_kms_client` and `test_backend` is provisioning PrivateKey with same tag `disk-encryption` and exporting private key with `Raw` format is not supported. 
- import export tests were failing from time to time because temporary files are written with the same path