### PR TITLE
fix: Findex concurrent tests on KMS encryption layer

### DIFF
--- a/crate/cli/src/actions/findex_server/findex/parameters.rs
+++ b/crate/cli/src/actions/findex_server/findex/parameters.rs
@@ -120,7 +120,7 @@ impl FindexParameters {
     ///
     /// # Errors
     /// - if no key id is provided
-    pub fn instantiate_keys(self) -> CosmianResult<FindexKeys> {
+    pub(crate) fn instantiate_keys(self) -> CosmianResult<FindexKeys> {
         match (self.seed_key_id, self.hmac_key_id, self.aes_xts_key_id) {
             (Some(seed_key_id), None, None) => Ok(FindexKeys::ClientSideEncryption {
                 seed_key_id,

--- a/crate/cli/src/actions/findex_server/tests/findex/basic.rs
+++ b/crate/cli/src/actions/findex_server/tests/findex/basic.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use cosmian_findex::{
     Value,
-    test_utils::{test_single_write_and_read, test_wrong_guard},
+    test_utils::{test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard},
 };
 use cosmian_findex_client::RestClient;
 use cosmian_findex_structs::CUSTOM_WORD_LENGTH;
@@ -271,13 +271,12 @@ async fn test_findex_sequential_wrong_guard() -> CosmianResult<()> {
     Ok(())
 }
 
-// Creating an issue to fix this test
-// #[tokio::test]
-// async fn test_findex_concurrent_read_write() -> CosmianResult<()> {
-//     test_guarded_write_concurrent(
-//         &create_encryption_layer::<CUSTOM_WORD_LENGTH>().await?,
-//         rand::random(),
-//     )
-//     .await;
-//     Ok(())
-// }
+#[tokio::test]
+async fn test_findex_concurrent_read_write() -> CosmianResult<()> {
+    test_guarded_write_concurrent(
+        &create_encryption_layer::<CUSTOM_WORD_LENGTH>().await?,
+        rand::random(),
+    )
+    .await;
+    Ok(())
+}

--- a/crate/findex_client/src/findex_rest_client.rs
+++ b/crate/findex_client/src/findex_rest_client.rs
@@ -1,4 +1,4 @@
-use base64::{Engine, engine::general_purpose};
+use base64::{Engine as _, engine::general_purpose};
 use cosmian_findex_structs::{
     Addresses, Bindings, Guard, OptionalWords,
     reexport::cosmian_findex::{ADDRESS_LENGTH, Address, MemoryADT},
@@ -16,6 +16,7 @@ pub struct FindexRestClient<const WORD_LENGTH: usize> {
 
 impl<const WORD_LENGTH: usize> FindexRestClient<WORD_LENGTH> {
     #[must_use]
+    #[inline]
     pub const fn new(rest_client: RestClient, index_id: Uuid) -> Self {
         Self {
             rest_client,
@@ -29,6 +30,7 @@ impl<const WORD_LENGTH: usize> MemoryADT for FindexRestClient<WORD_LENGTH> {
     type Error = ClientError;
     type Word = [u8; WORD_LENGTH];
 
+    #[inline]
     async fn batch_read(
         &self,
         addresses: Vec<Self::Address>,
@@ -68,6 +70,7 @@ impl<const WORD_LENGTH: usize> MemoryADT for FindexRestClient<WORD_LENGTH> {
         Ok(words.into_inner())
     }
 
+    #[inline]
     async fn guarded_write(
         &self,
         guard: (Self::Address, Option<Self::Word>),

--- a/crate/findex_client/src/kms/memory_adt.rs
+++ b/crate/findex_client/src/kms/memory_adt.rs
@@ -153,7 +153,7 @@ mod tests {
 
     use cosmian_findex::{
         InMemory,
-        test_utils::{test_single_write_and_read, test_wrong_guard},
+        test_utils::{test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard},
     };
     use cosmian_findex_structs::CUSTOM_WORD_LENGTH;
     use cosmian_kms_client::{
@@ -390,13 +390,12 @@ mod tests {
         Ok(())
     }
 
-    // Creating an issue to fix this test
-    // #[tokio::test]
-    // async fn test_concurrent_read_write() -> ClientResult<()> {
-    //     log_init(None);
-    //     let ctx = start_default_test_kms_server().await;
-    //     let memory = create_test_layer(ctx.owner_client_conf.kms_config.clone()).await?;
-    //     test_guarded_write_concurrent::<CUSTOM_WORD_LENGTH, _>(&memory, rand::random()).await;
-    //     Ok(())
-    // }
+    #[tokio::test]
+    async fn test_concurrent_read_write() -> ClientResult<()> {
+        log_init(None);
+        let ctx = start_default_test_kms_server().await;
+        let memory = create_test_layer(ctx.owner_client_conf.kms_config.clone()).await?;
+        test_guarded_write_concurrent::<CUSTOM_WORD_LENGTH, _>(&memory, rand::random()).await;
+        Ok(())
+    }
 }


### PR DESCRIPTION
- re-enable concurrency tests with Findex client